### PR TITLE
More options for the generated filename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ Options
 
 You have a couple of formatting options via attributes of the fenced code block to control the rendering
 
-- Pandoc caption and automatic image numbering - Use `{.mermaid caption="Caption Text Here"}`
+- Pandoc caption, the filename is this value cleaned up - Use `{.mermaid caption="Caption Text Here"}`
 - Image Format - Use `{.mermaid format=svg}`     Default is png
 - Width  - Use `{.mermaid width=400}`     default with is 500
 - Theme - Use `{.mermaid theme=forest}` default is 'default'. Corresponds to `--theme`  flag of mermaid.cli
+- Filename - Use `{.mermaid filename="file with space"}` to set the filename. This has priority over the caption
 - Save path - Use `{.mermaid loc=img}`  default loc=inline which will
   encode the image in a `data uri` scheme.
     - Possible values for `loc`

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mermaid": "^7.1.2",
     "mermaid.cli": "^0.4.6",
     "pandoc-filter": "^0.1.3",
-    "tmp": "0.0.28"
+    "tmp": "0.0.28",
+    "sanitize-filename": "1.6.1"
   }
 }


### PR DESCRIPTION
Use `caption` if provided (percent escaped) for the filename.
Additional option (that precedes `caption`) `filename` introduced that
can be used to specify the filname used to generate the file.

Example:

```
~~~{.mermaid filename="this is the filename without extension"}
~~~

~~~{.mermaid caption="this caption is also the filename"}
~~~

~~~{.mermaid caption="this caption is not the filename"
  filename="this_is_the_filename"}
~~~
```