### PR TITLE
Fixes #58

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,11 @@ var cmd = externalTool("mmdc");
 var imgur = externalTool("imgur");
 var counter = 0;
 var folder = process.cwd()
+// Create a writeable stream to redirect stderr to file - if it logs to stdout, then pandoc hangs due to improper json.
+// errorLog is used in pandoc.toJSONFilter
+var errFile = path.join(folder,  "mermaid-filter.err");
+var errorLog = fs.createWriteStream(errFile);
+
 // console.log(folder)
 function mermaid(type, value, format, meta) {
     if (type != "CodeBlock") return null;
@@ -135,10 +140,7 @@ function firstExisting(paths, error) {
 }
 
 pandoc.toJSONFilter(function(type, value, format, meta) {
-    // redirect stderr to file - if it logs to stdout, then pandoc hangs due to improper json
-    errFile = path.join(folder,  "mermaid-filter.err");
-    errorLog = fs.createWriteStream(errFile);
-    var origStdErr = process.stderr.write;
+	// Redirect stderr to a globally created writeable stream
     process.stderr.write = errorLog.write.bind(errorLog);
     return mermaid(type, value, format, meta);
 });


### PR DESCRIPTION
Did some debugging of the EMFILE too many files when running on Windows 10 issue and noticed that an instance of `node` was running away with over 8000 handles, and they were nearly all for `mermaid-filter.err`...

So I've changed the scope of the writeable file stream so only was is created and it gets re-used.

I tried cleaning the stream up in the callback but didn't know how to do it.
I'm a C++ developer who is JS noob... :-)

So I just changed the scope....

Feel free to fix it properly, but the root cause is a handle leak for that writeable stream...



