### PR TITLE
Add image class option

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ function mermaid(type, value, format, meta) {
         loc: process.env.MERMAID_FILTER_LOC || 'inline',
         theme: process.env.MERMAID_FILTER_THEME || 'default',
         caption: process.env.MERMAID_FILTER_CAPTION || '',
-        filename: process.env.MERMAID_FILTER_FILENAME || ''
+        filename: process.env.MERMAID_FILTER_FILENAME || '',
+        imageClass: process.env.MERMAID_FILTER_IMAGE_CLASS || ''
     };
     var configFile = path.join(folder, ".mermaid-config.json")
     var confFileOpts = ""
@@ -104,10 +105,13 @@ function mermaid(type, value, format, meta) {
     if (options.caption != "") {
         fig = "fig:";
     }
+
+    var imageClasses = options.imageClass ? [options.imageClass] : []
+
     return pandoc.Para(
         [
             pandoc.Image(
-                [id, [], []],
+                [id, imageClasses, []],
                 [pandoc.Str(options.caption)],
                 [newPath, fig]
             )


### PR DESCRIPTION
# Summary 

This change adds an image class option to the rendered HTML IMG tag so that it can be styled more easily with CSS.

Image class can be added in two ways
1. by specifying the option in the options block of fenced code blocks
   ```markdown
     ```{.mermaid imageClass="my-image-class"}
     ...
     ```
2. or by setting the environment variable _MERMAID_FILTER_IMAGE_CLASS_
    ```bash
    export MERMAID_FILTER_IMAGE_CLASS=mermaid-diagram
    ```

# Example

```bash
gh repo clone raghur/mermaid-filter
cd mermaid-filter
git checkout add-image-class-option
npm install
npm link 
pandoc --filter mermaid-filter --from markdown --to html /tmp/mermaid-image-class-option.md > /tmp/mermaid-image-class-option.html && open /tmp/mermaid-image-class-option.html
```

where /tmp/mermaid-image-class-option.md has the following content

~~~markdown
<style scoped>
.mermaid-diagram {
  border: 1px red solid;
  width: 100%;
}
</style>

```{.mermaid imageClass=mermaid-diagram format=svg theme=forest #fig-1}
flowchart LR
    Start --> Stop
```
~~~

will render a page where the rendered Mermaid flowchart has a red border and 100% width.

<img width="1504" alt="mermaid-image-class-option" src="https://user-images.githubusercontent.com/40720053/148402506-299cf531-05d9-4256-85cf-a5baf0a4c896.png">

