### PR TITLE
Add background option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You have a couple of formatting options via attributes of the fenced code block 
 - Image Format - Use `{.mermaid format=svg}`     Default is png
 - Width  - Use `{.mermaid width=400}`     default width is 800
 - Theme - Use `{.mermaid theme=forest}` default is 'default'. Corresponds to `--theme`  flag of mermaid.cli
+- Background - Use `{.mermaid background=transparent}` default is 'white'. Correponds to `--backgroundColor` flag of mermaid.cli
 - Filename - Use `{.mermaid filename="file with space"}` to set the filename. This has priority over the caption
 - Save path - Use `{.mermaid loc=img}`  default loc=inline which will
   encode the image in a `data uri` scheme.

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function mermaid(type, value, format, meta) {
         format: process.env.MERMAID_FILTER_FORMAT || 'png',
         loc: process.env.MERMAID_FILTER_LOC || 'inline',
         theme: process.env.MERMAID_FILTER_THEME || 'default',
+        background: process.env.MERMAID_FILTER_BACKROUND || 'white',
         caption: process.env.MERMAID_FILTER_CAPTION || '',
         filename: process.env.MERMAID_FILTER_FILENAME || '',
         imageClass: process.env.MERMAID_FILTER_IMAGE_CLASS || ''
@@ -77,7 +78,7 @@ function mermaid(type, value, format, meta) {
 
     var savePath = tmpfileObj.name + "." + options.format
     var newPath = path.join(outdir, `${options.filename}.${options.format}`);
-    var fullCmd = `${cmd}  ${confFileOpts} ${puppeteerOpts} -w ${options.width} -f -i ${tmpfileObj.name} -t ${options.theme} -o ${savePath}`
+    var fullCmd = `${cmd}  ${confFileOpts} ${puppeteerOpts} -w ${options.width} -f -i ${tmpfileObj.name} -t ${options.theme} -b ${options.background} -o ${savePath}`
     // console.log(fullCmd, savePath)
     exec(fullCmd);
     //console.log(oldPath, newPath);


### PR DESCRIPTION
This PR allows to specify `--backgroundColor` for mermaid.cli.
I was unsuccessful using CSS, and having a simple option seems relevant.
Fixes  #38

Thanks for you work !

