### PR TITLE
Fix environment variable name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Admittedly, this is uglier than the earlier syntax on top - but that's how Pando
 |`background` | `white`       | `MERMAID_FILTER_BACKGROUND` |Correponds to `--backgroundColor` flag of mermaid.cli|
 | `filename`  | NA            | `MERMAID_FILTER_FILENAME`| Takes precedence |
 | `loc`| `inline` | `MERMAID_FILTER_LOC`| inline - generates a data url; `imgur` - uploads to imgur; `loc=anythingelse` saves images to folder `anythingelse`
-| `scale` | 1|`MERMAILD_FILTER_SCALE`| |
+| `scale` | 1|`MERMAID_FILTER_SCALE`| |
 | `imageclass` ||`MERMAID_FILTER_IMAGECLASS`| |
 
 You can also specify an ID to be applied to the rendered image. This may be useful to use [`pandoc-crossref`](https://github.com/lierdakil/pandoc-crossref) or similar packages to reference your diagrams, for example:


### PR DESCRIPTION
There's a typo in the environment variable name for controlling the *scale* parameter.