### PR TITLE
mermaid-cli v11

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// #! /usr/bin/env node
+#! /usr/bin/env node
 const pandoc = require('pandoc-filter')
 const process = require('process')
 const utils = require('./lib/filter')

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mermaid-filter": "index.js"
   },
   "dependencies": {
-    "@mermaid-js/mermaid-cli": "^10",
+    "@mermaid-js/mermaid-cli": "^11",
     "imgur": "^0.3.1",
     "minimist": ">=0.2.1",
     "pandoc-filter": "^0.1.3",


### PR DESCRIPTION
uped version of mermaid-cli to 11 to get the new puppeteer version, as the older couldn't find the cache.
Also shebang needed to be activated for filter to run.